### PR TITLE
pcxtool bug fixes and new command

### DIFF
--- a/src/tools/pcxtool/pcxtool.c
+++ b/src/tools/pcxtool/pcxtool.c
@@ -59,6 +59,7 @@ int showref, dump_palette;
 int swap, swapfrom, swapto;
 int pcepal;
 int fixmask, maskcolor;
+int reverse;
 
 
 /* and now for the program */
@@ -121,6 +122,7 @@ usage(void)
    printf("                 hexadecimal (prefixed by '$' or '0x')\n");
    printf("-fixmask color : ensures that 'color', if used, is the first color in all 16 sub-palettes.\n");
    printf("                 'color' may be a decimal value (no prefix) or hexadecimal (prefixed by '$' or '0x'\n");
+   printf("-reverse       : reverse palette entries without changing the appearance (photoshop fixup)\n");
 }
 
 
@@ -239,6 +241,21 @@ int num_swapped = 0;
    if (num_swapped == 0)
    {
       printf("\nNo color found that matches '0x%X'\n", maskcolor);
+   }
+}
+
+void
+reverse_palette(void)
+{
+int i;
+int j;
+
+   for (i = 0; i < MAX_PAL / 2; i++)
+   {
+      j = MAX_PAL - i - 1;
+      swapto = i;
+      swapfrom = j;
+      swap_palette();
    }
 }
 
@@ -473,6 +490,11 @@ int cmd_err;
          maskcolor = get_val(argv[argcnt++]);
          printf("maskcolor = %d\n", maskcolor);
       }
+      else if (strcasecmp(argv[argcnt], "-reverse") == 0)
+      {
+         reverse = 1;
+         argcnt++;
+      }
       else
       {
          cmd_err = 1;
@@ -504,6 +526,11 @@ int cmd_err;
    if (swap)
    {
       swap_palette();
+   }
+
+   if (reverse)
+   {
+      reverse_palette();
    }
 
    if (fixmask)

--- a/src/tools/pcxtool/pcxtool.c
+++ b/src/tools/pcxtool/pcxtool.c
@@ -13,6 +13,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined _WIN32 || defined _WIN64
+#define strcasecmp stricmp
+#endif
+
 
 /* PCX header info */
 
@@ -387,32 +391,32 @@ int cmd_err;
 
    while ((argcnt < argc) && (argv[argcnt][0] == '-'))
    {
-      if (strncasecmp(argv[argcnt], "-help", 5) == 0)
+      if (strcasecmp(argv[argcnt], "-help") == 0)
       {
          usage();
          exit(0);
       }
-      else if (strncasecmp(argv[argcnt], "-pcepal2", 8) == 0)
+      else if (strcasecmp(argv[argcnt], "-pcepal2") == 0)
       {
          pcepal = 2;
          argcnt++;
       }
-      else if (strncasecmp(argv[argcnt], "-pcepal", 7) == 0)
+      else if (strcasecmp(argv[argcnt], "-pcepal") == 0)
       {
          pcepal = 1;
          argcnt++;
       }
-      else if (strncasecmp(argv[argcnt], "-dump", 5) == 0)
+      else if (strcasecmp(argv[argcnt], "-dump") == 0)
       {
          dump_palette = 1;
          argcnt++;
       }
-      else if (strncasecmp(argv[argcnt], "-ref", 4) == 0)
+      else if (strcasecmp(argv[argcnt], "-ref") == 0)
       {
          showref = 1;
          argcnt++;
       }
-      else if (strncasecmp(argv[argcnt], "-swap", 5) == 0)
+      else if (strcasecmp(argv[argcnt], "-swap") == 0)
       {
          if ((argcnt + 3) >= argc)
          {

--- a/src/tools/pcxtool/pcxtool.c
+++ b/src/tools/pcxtool/pcxtool.c
@@ -376,7 +376,7 @@ int repeat, temp;
          temp = pixel[y*MAX_X+x];
 
          if ( (repeat == 0x3F) ||
-              (x >= pcxhdr.bytes_line) ||
+              (x >= pcxhdr.bytes_line-1) ||
               (temp != pixel[y*MAX_X+x+1]) )
          {
             if ((repeat > 1) || ((temp & 0xc0) == 0xc0))

--- a/src/tools/pcxtool/pcxtool.c
+++ b/src/tools/pcxtool/pcxtool.c
@@ -45,7 +45,7 @@ pcx_header pcxhdr;
 
 /* for now, maximum size of image = 256 x 256 pixels */
 
-char pixel[MAX_X*MAX_Y];
+unsigned char pixel[MAX_X*MAX_Y];
 
 char palette_reference[MAX_PAL];
 

--- a/src/tools/pcxtool/pcxtool.c
+++ b/src/tools/pcxtool/pcxtool.c
@@ -47,7 +47,7 @@ pcx_header pcxhdr;
 
 unsigned char pixel[MAX_X*MAX_Y];
 
-char palette_reference[MAX_PAL];
+unsigned int palette_reference[MAX_PAL];
 
 unsigned char pal_r[MAX_PAL];
 unsigned char pal_g[MAX_PAL];


### PR DESCRIPTION
Fixed some bugs I found in pcxtool and added a new command to swap the transparent color to the first palette index. This makes the workflow a lot easier for me when working in Photoshop which saves the palette in reversed order.
